### PR TITLE
Implement processes

### DIFF
--- a/src/process.js
+++ b/src/process.js
@@ -1,0 +1,71 @@
+const {executeCommands: executeCommandsRaw} = require('./command.js')
+const {maintainProjection} = require('./projection.js')
+
+module.exports = {
+  maintainProcess,
+}
+
+function maintainProcess (pgPool, name, process, options = {}) {
+  const processName = `process.${name}`
+  const projectionName = `recluse.${processName}`
+  const {commandTypes, createInitialState, eventTypes, handleEvent, routeEvent} = process
+  const {timeout, clock} = options
+
+  async function apply (pgClient, event) {
+    if (!eventTypes.includes(event.type)) return false
+
+    const id = routeEvent(event)
+
+    if (!id) return false
+
+    const state = await readState(pgClient, id, createInitialState)
+
+    let shouldReplaceState = false
+    let nextState
+    const executedCommands = []
+
+    function executeCommands (...commands) {
+      commands.forEach(command => {
+        const {type} = command
+
+        if (!commandTypes.includes(type)) throw new Error(`Process ${name} cannot execute ${type} commands`)
+
+        executedCommands.push(command)
+      })
+    }
+
+    function replaceState (state) {
+      shouldReplaceState = true
+      nextState = state
+    }
+
+    await handleEvent({event, executeCommands, replaceState, state})
+    await executeCommandsRaw(pgClient, processName, executedCommands)
+    if (shouldReplaceState) await writeState(pgClient, name, id, nextState)
+
+    return true
+  }
+
+  return maintainProjection(pgPool, projectionName, apply, {timeout, clock})
+}
+
+async function readState (pgClient, id, createInitialState) {
+  const result = await pgClient.query(
+    'SELECT data FROM recluse.process WHERE id = $1',
+    [id]
+  )
+
+  if (result.rowCount > 0) return result.rows[0].data
+
+  return createInitialState()
+}
+
+async function writeState (pgClient, name, id, state) {
+  await pgClient.query(
+    `
+    INSERT INTO recluse.process (name, id, data) VALUES ($1, $2, $3)
+    ON CONFLICT (name, id) DO UPDATE SET data = $3
+    `,
+    [name, id, state]
+  )
+}

--- a/src/schema.js
+++ b/src/schema.js
@@ -100,4 +100,15 @@ async function initializeSchema (pgClient) {
   await pgClient.query(`
     ALTER SEQUENCE recluse.projection_id_seq OWNED BY recluse.projection.id
   `)
+
+  await pgClient.query(`
+    CREATE TABLE IF NOT EXISTS recluse.process
+    (
+      name text NOT NULL,
+      id text NOT NULL,
+      data bytea DEFAULT NULL,
+
+      PRIMARY KEY (name, id)
+    )
+  `)
 }

--- a/test/suite/maintain-process.spec.js
+++ b/test/suite/maintain-process.spec.js
@@ -1,0 +1,392 @@
+const {createSandbox, match} = require('sinon')
+const {expect} = require('chai')
+
+const {asyncIterableToArray, consumeAsyncIterable, jsonBuffer, parseJsonBuffer, pgSpec} = require('../helper.js')
+const {createClock} = require('../clock.js')
+
+const {appendEvents} = require('../../src/event.js')
+const {initializeSchema} = require('../../src/schema.js')
+const {maintainProcess} = require('../../src/process.js')
+const {readCommands} = require('../../src/command.js')
+
+describe('maintainProcess()', pgSpec(function () {
+  const nameA = 'process-name-a'
+  const idA = 'process-id-a'
+  const streamTypeA = 'stream-type-a'
+  const streamNameA = 'stream-name-a'
+  const eventTypeA = 'event-type-a'
+  const eventTypeB = 'event-type-b'
+  const commandTypeA = 'command-type-a'
+  const commandTypeB = 'command-type-b'
+  const eventA = {type: eventTypeA, data: jsonBuffer(111)}
+  const eventB = {type: eventTypeB, data: jsonBuffer(222)}
+  const eventC = {type: eventTypeA, data: jsonBuffer(333)}
+  const eventD = {type: eventTypeB, data: jsonBuffer(444)}
+
+  const emptyProcess = {
+    eventTypes: [],
+    commandTypes: [],
+    routeEvent: () => idA,
+    createInitialState: () => jsonBuffer(null),
+    handleEvent: () => {},
+  }
+
+  beforeEach(async function () {
+    this.sandbox = createSandbox()
+
+    await initializeSchema(this.pgClient)
+  })
+
+  afterEach(function () {
+    this.sandbox.restore()
+  })
+
+  context('before iteration', function () {
+    it('should support cancellation', async function () {
+      const process = {
+        ...emptyProcess,
+      }
+      this.sandbox.spy(process, 'routeEvent')
+      await appendEvents(this.pgClient, streamTypeA, streamNameA, 0, [eventA])
+      await maintainProcess(this.pgClient, nameA, emptyProcess).cancel()
+
+      expect(process.routeEvent).to.not.have.been.called()
+    })
+  })
+
+  context('while iterating', function () {
+    beforeEach(async function () {
+      await appendEvents(this.pgClient, streamTypeA, streamNameA, 0, [eventA, eventB])
+    })
+
+    it('should process the events in the correct order', async function () {
+      const process = {
+        ...emptyProcess,
+        eventTypes: [eventTypeA, eventTypeB],
+        commandTypes: [commandTypeA],
+        createInitialState: () => jsonBuffer(0),
+        handleEvent: async ({event: {data}, executeCommands, replaceState, state}) => {
+          const number = parseJsonBuffer(data)
+          const total = parseJsonBuffer(state) + number
+
+          executeCommands({type: commandTypeA, data: jsonBuffer({total, number})})
+          replaceState(jsonBuffer(total))
+        },
+      }
+      await consumeAsyncIterable(
+        maintainProcess(this.pgPool, nameA, process),
+        2,
+        process => process.cancel(),
+        wasProcessed => expect(wasProcessed).to.be.true()
+      )
+      const [commands] = await asyncIterableToArray(readCommands(this.pgClient))
+
+      expect(commands).to.have.length(2)
+      expect(commands[0].command).to.have.fields({type: commandTypeA, data: jsonBuffer({total: 111, number: 111})})
+      expect(commands[1].command).to.have.fields({type: commandTypeA, data: jsonBuffer({total: 333, number: 222})})
+    })
+
+    it('should update the state only when replaceState() is called', async function () {
+      await appendEvents(this.pgClient, streamTypeA, streamNameA, 2, [eventC])
+
+      const process = {
+        ...emptyProcess,
+        eventTypes: [eventTypeA, eventTypeB],
+        commandTypes: [commandTypeA],
+        createInitialState: () => jsonBuffer(0),
+        handleEvent: async ({event: {data, type}, executeCommands, replaceState, state}) => {
+          const number = parseJsonBuffer(data)
+          const total = parseJsonBuffer(state) + number
+
+          executeCommands({type: commandTypeA, data: jsonBuffer({total, number})})
+
+          if (type === eventTypeA) {
+            replaceState(jsonBuffer(total))
+          } else {
+            jsonBuffer(total).copy(state)
+          }
+        },
+      }
+      await consumeAsyncIterable(
+        maintainProcess(this.pgPool, nameA, process),
+        3,
+        process => process.cancel(),
+        wasProcessed => expect(wasProcessed).to.be.true()
+      )
+      const [commands] = await asyncIterableToArray(readCommands(this.pgClient))
+
+      expect(commands).to.have.length(3)
+      expect(commands[0].command).to.have.fields({type: commandTypeA, data: jsonBuffer({total: 111, number: 111})})
+      expect(commands[1].command).to.have.fields({type: commandTypeA, data: jsonBuffer({total: 333, number: 222})})
+      expect(commands[2].command).to.have.fields({type: commandTypeA, data: jsonBuffer({total: 444, number: 333})})
+    })
+
+    it('should process different event types', async function () {
+      const process = {
+        ...emptyProcess,
+        eventTypes: [eventTypeA, eventTypeB],
+        commandTypes: [commandTypeA, commandTypeB],
+        handleEvent: async ({event: {type: eventType}, executeCommands}) => {
+          const type = eventType === eventTypeA ? commandTypeA : commandTypeB
+
+          executeCommands({type, data: jsonBuffer({eventType})})
+        },
+      }
+      await consumeAsyncIterable(
+        maintainProcess(this.pgPool, nameA, process),
+        2,
+        process => process.cancel(),
+        wasProcessed => expect(wasProcessed).to.be.true()
+      )
+      const [commands] = await asyncIterableToArray(readCommands(this.pgClient))
+
+      expect(commands).to.have.length(2)
+      expect(commands[0].command).to.have.fields({type: commandTypeA, data: jsonBuffer({eventType: eventTypeA})})
+      expect(commands[1].command).to.have.fields({type: commandTypeB, data: jsonBuffer({eventType: eventTypeB})})
+    })
+
+    it('should ignore event types that should not be processed', async function () {
+      const process = {
+        ...emptyProcess,
+        eventTypes: [eventTypeA],
+        commandTypes: [commandTypeA],
+        handleEvent: async ({event: {type}, executeCommands}) => {
+          executeCommands({type: commandTypeA, data: jsonBuffer({type})})
+        },
+      }
+      const expectedWasProcesed = [true, false]
+      await consumeAsyncIterable(
+        maintainProcess(this.pgPool, nameA, process),
+        2,
+        process => process.cancel(),
+        (wasProcessed, i) => expect(wasProcessed).to.equal(expectedWasProcesed[i])
+      )
+      const [commands] = await asyncIterableToArray(readCommands(this.pgClient))
+
+      expect(commands).to.have.length(1)
+      expect(commands[0].command).to.have.fields({type: commandTypeA, data: jsonBuffer({type: eventTypeA})})
+    })
+
+    it('should ignore event types that do not route to a process ID', async function () {
+      const process = {
+        ...emptyProcess,
+        eventTypes: [eventTypeA, eventTypeB],
+        commandTypes: [commandTypeA],
+        routeEvent: ({type}) => type === eventTypeA ? idA : null,
+        handleEvent: async ({event: {type}, executeCommands}) => {
+          executeCommands({type: commandTypeA, data: jsonBuffer({type})})
+        },
+      }
+      const expectedWasProcesed = [true, false]
+      await consumeAsyncIterable(
+        maintainProcess(this.pgPool, nameA, process),
+        2,
+        process => process.cancel(),
+        (wasProcessed, i) => expect(wasProcessed).to.equal(expectedWasProcesed[i])
+      )
+      const [commands] = await asyncIterableToArray(readCommands(this.pgClient))
+
+      expect(commands).to.have.length(1)
+      expect(commands[0].command).to.have.fields({type: commandTypeA, data: jsonBuffer({type: eventTypeA})})
+    })
+
+    it('should throw if an unexpected commnd is executed', async function () {
+      const process = maintainProcess(this.pgPool, nameA, {
+        ...emptyProcess,
+        eventTypes: [eventTypeA],
+        commandTypes: [commandTypeA],
+        handleEvent: async ({executeCommands}) => {
+          executeCommands({type: commandTypeB})
+        },
+      })
+
+      await expect(consumeAsyncIterable(process, 1))
+        .to.be.rejectedWith(`Process ${nameA} cannot execute ${commandTypeB} commands`)
+
+      await process.cancel()
+    })
+
+    it('should handle errors while processing events', async function () {
+      const releases = []
+      const pool = {
+        connect: async () => {
+          const client = await this.createPgClient()
+          this.sandbox.spy(client, 'release')
+          releases.push(client.release)
+
+          return client
+        },
+      }
+      const error = new Error('You done goofed')
+      const process = maintainProcess(pool, nameA, {
+        ...emptyProcess,
+        eventTypes: [eventTypeA, eventTypeB],
+        handleEvent: async () => { throw error },
+      })
+
+      await expect(consumeAsyncIterable(process, 1)).to.be.rejectedWith(error)
+
+      await process.cancel()
+    })
+
+    it('should be able to process new events when relying solely on notifications', async function () {
+      const process = {
+        ...emptyProcess,
+        eventTypes: [eventTypeA, eventTypeB],
+        commandTypes: [commandTypeA],
+        handleEvent: async ({event: {data}, executeCommands}) => {
+          executeCommands({type: commandTypeA, data})
+        },
+      }
+      await Promise.all([
+        consumeAsyncIterable(
+          maintainProcess(this.pgPool, nameA, process, {timeout: null}),
+          4,
+          process => process.cancel()
+        ),
+
+        appendEvents(this.pgClient, streamTypeA, streamNameA, 2, [eventC, eventD]),
+      ])
+      const [commands] = await asyncIterableToArray(readCommands(this.pgClient))
+
+      expect(commands).to.have.length(4)
+      expect(commands[0].command).to.have.fields({type: commandTypeA, data: eventA.data})
+      expect(commands[1].command).to.have.fields({type: commandTypeA, data: eventB.data})
+      expect(commands[2].command).to.have.fields({type: commandTypeA, data: eventC.data})
+      expect(commands[3].command).to.have.fields({type: commandTypeA, data: eventD.data})
+    })
+
+    it('should process new events when a notification is received before the timeout', async function () {
+      const clock = createClock()
+      const process = {
+        ...emptyProcess,
+        eventTypes: [eventTypeA, eventTypeB],
+        commandTypes: [commandTypeA],
+        handleEvent: async ({event: {data}, executeCommands}) => {
+          executeCommands({type: commandTypeA, data})
+        },
+      }
+      await Promise.all([
+        consumeAsyncIterable(
+          maintainProcess(this.pgPool, nameA, process, {clock}),
+          4,
+          process => process.cancel()
+        ),
+
+        appendEvents(this.pgClient, streamTypeA, streamNameA, 2, [eventC, eventD]),
+      ])
+      const [commands] = await asyncIterableToArray(readCommands(this.pgClient))
+
+      expect(commands).to.have.length(4)
+      expect(commands[0].command).to.have.fields({type: commandTypeA, data: eventA.data})
+      expect(commands[1].command).to.have.fields({type: commandTypeA, data: eventB.data})
+      expect(commands[2].command).to.have.fields({type: commandTypeA, data: eventC.data})
+      expect(commands[3].command).to.have.fields({type: commandTypeA, data: eventD.data})
+    })
+
+    it('should process new events when the timeout fires before receiving a notification', async function () {
+      const clock = createClock({immediate: true})
+
+      const appendClient = await this.createPgClient()
+      this.sandbox.stub(appendClient, 'query')
+      appendClient.query.withArgs(match('NOTIFY')).callsFake(async () => {})
+      appendClient.query.callThrough()
+
+      const process = {
+        ...emptyProcess,
+        eventTypes: [eventTypeA, eventTypeB],
+        commandTypes: [commandTypeA],
+        handleEvent: async ({event: {data}, executeCommands}) => {
+          executeCommands({type: commandTypeA, data})
+        },
+      }
+      await Promise.all([
+        consumeAsyncIterable(
+          maintainProcess(this.pgPool, nameA, process, {clock}),
+          4,
+          process => process.cancel()
+        ),
+
+        appendEvents(appendClient, streamTypeA, streamNameA, 2, [eventC, eventD]),
+      ])
+      const [commands] = await asyncIterableToArray(readCommands(this.pgClient))
+
+      expect(commands).to.have.length(4)
+      expect(commands[0].command).to.have.fields({type: commandTypeA, data: eventA.data})
+      expect(commands[1].command).to.have.fields({type: commandTypeA, data: eventB.data})
+      expect(commands[2].command).to.have.fields({type: commandTypeA, data: eventC.data})
+      expect(commands[3].command).to.have.fields({type: commandTypeA, data: eventD.data})
+    })
+  })
+
+  context('when resuming the maintenance of an existing process', function () {
+    beforeEach(async function () {
+      this.process = {
+        ...emptyProcess,
+        eventTypes: [eventTypeA, eventTypeB],
+        commandTypes: [commandTypeA],
+        handleEvent: async ({event: {data}, executeCommands}) => {
+          executeCommands({type: commandTypeA, data})
+        },
+      }
+
+      await appendEvents(this.pgClient, streamTypeA, streamNameA, 0, [eventA, eventB])
+      await consumeAsyncIterable(
+        maintainProcess(this.pgPool, nameA, this.process),
+        2,
+        process => process.cancel()
+      )
+    })
+
+    it('should process new events in the correct order', async function () {
+      await Promise.all([
+        consumeAsyncIterable(
+          maintainProcess(this.pgPool, nameA, this.process, {timeout: null}),
+          2,
+          process => process.cancel()
+        ),
+
+        appendEvents(this.pgClient, streamTypeA, streamNameA, 2, [eventC, eventD]),
+      ])
+      const [commands] = await asyncIterableToArray(readCommands(this.pgClient))
+
+      expect(commands).to.have.length(4)
+      expect(commands[0].command).to.have.fields({type: commandTypeA, data: eventA.data})
+      expect(commands[1].command).to.have.fields({type: commandTypeA, data: eventB.data})
+      expect(commands[2].command).to.have.fields({type: commandTypeA, data: eventC.data})
+      expect(commands[3].command).to.have.fields({type: commandTypeA, data: eventD.data})
+    })
+  })
+
+  context('when multiple workers try to maintain the same process', function () {
+    it('should cooperatively process events using a single worker at a time', async function () {
+      const process = {
+        ...emptyProcess,
+        eventTypes: [eventTypeA, eventTypeB],
+        commandTypes: [commandTypeA],
+        handleEvent: async ({event: {data}, executeCommands}) => {
+          executeCommands({type: commandTypeA, data})
+        },
+      }
+      const maintain = () => consumeAsyncIterable(
+        maintainProcess(this.pgPool, nameA, process, {timeout: null}),
+        2,
+        process => process.cancel()
+      )
+
+      await Promise.all([
+        maintain(),
+        maintain(),
+
+        appendEvents(this.pgClient, streamTypeA, streamNameA, 0, [eventA, eventB, eventC, eventD]),
+      ])
+      const [commands] = await asyncIterableToArray(readCommands(this.pgClient))
+
+      expect(commands).to.have.length(4)
+      expect(commands[0].command).to.have.fields({type: commandTypeA, data: eventA.data})
+      expect(commands[1].command).to.have.fields({type: commandTypeA, data: eventB.data})
+      expect(commands[2].command).to.have.fields({type: commandTypeA, data: eventC.data})
+      expect(commands[3].command).to.have.fields({type: commandTypeA, data: eventD.data})
+    })
+  })
+}))


### PR DESCRIPTION
Specifying a process will look something like this:

```js
const app = {
  processes: {
    processName: {
      eventTypes: ['event-type-a', 'event-type-b'],
      commandTypes: ['command-type-a', 'command-type-b'],
      routeEvent: event => event.id,
      createInitialState: () => ({a: 'b', c: 'd'}),
      handleEvent: ({event: {type, data}, executeCommands, replaceState, state}) => {
        // process logic
      },
    },
  },
}
```

- Processes will be implemented on top of the existing projection system, so only a basic schema is needed for storing state after each event is processed.
- Commands produced by processes will be handled out-of-band by the existing [`maintainCommandHandler()`](https://github.com/ezzatron/recluse/blob/c68dfd8/src/command.js#L64) system (not part of this PR), so there's no special logic surrounding commands.
- Processes can route events to "nothing" without exploding, even if they list the event type as one that they handle. I think this is as it should be - @jmalloc?
- The `state` variable passed to `handleEvent` is mutable and will always be re-persisted when events are handled. In practice this seems unlikely since the state is always a binary buffer, but I didn't want to take away that power.
- The state can also be explicitly replaced using the `replaceState` callback. This is probably the more common use-case when the state needs to be deserialized, then serialized again for persisting.