### PR TITLE
Refactor handler state management

### DIFF
--- a/src/serialization/json.js
+++ b/src/serialization/json.js
@@ -1,8 +1,13 @@
 module.exports = {
   serialization: {
+    copy,
     serialize,
     unserialize,
   },
+}
+
+function copy (data) {
+  return JSON.parse(JSON.stringify(data))
 }
 
 function serialize (data) {

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,49 @@
+module.exports = {
+  createStateController,
+}
+
+function createStateController (copy, read) {
+  let isReadFlag = false
+  let isUpdatedFlag = false
+  let state = null
+
+  async function getState () {
+    if (!isReadFlag) {
+      state = await read()
+      isReadFlag = true
+    }
+
+    return state
+  }
+
+  function isUpdated () {
+    return isUpdatedFlag
+  }
+
+  async function readState () {
+    return copy(await getState())
+  }
+
+  async function updateState (produce) {
+    if (typeof produce !== 'function') {
+      state = copy(produce)
+      isReadFlag = true
+      isUpdatedFlag = true
+
+      return
+    }
+
+    const draft = await readState()
+    const result = await produce(draft)
+
+    state = copy(typeof result === 'undefined' ? draft : result)
+    isUpdatedFlag = true
+  }
+
+  return {
+    getState,
+    isUpdated,
+    readState,
+    updateState,
+  }
+}

--- a/test/suite/create-state-controller.spec.js
+++ b/test/suite/create-state-controller.spec.js
@@ -1,0 +1,284 @@
+const {expect} = require('chai')
+const {spy} = require('sinon')
+
+const {createStateController} = require('../../src/state.js')
+const {serialization: {copy}} = require('../../src/serialization/json.js')
+
+describe('createStateController()', function () {
+  const increment = async state => { state.number++ }
+  const nest = async state => ({state})
+  const destroy = async () => null
+  const error = new Error('You done goofed')
+  const explode = () => { throw error }
+
+  beforeEach(function () {
+    this.init = {number: 0}
+    this.read = spy(async () => this.init)
+
+    this.controller = createStateController(copy, this.read)
+  })
+
+  context('when the state has not been read', function () {
+    it('should not be flagged as needing an update', function () {
+      expect(this.controller.isUpdated()).to.be.false()
+    })
+
+    describe('getState()', function () {
+      it('should be able to return the state', async function () {
+        expect(await this.controller.readState()).to.deep.equal(this.init)
+      })
+    })
+
+    describe('readState()', function () {
+      it('should be able to read the state', async function () {
+        expect(await this.controller.readState()).to.deep.equal(this.init)
+      })
+
+      it('should return a copy of the state', async function () {
+        expect(await this.controller.readState()).to.not.equal(this.init)
+      })
+    })
+
+    describe('updateState()', function () {
+      it('should be able to update the state by mutation', async function () {
+        await this.controller.updateState(increment)
+
+        expect(await this.controller.readState()).to.deep.equal({number: 1})
+      })
+
+      it('should be able to replace the state by supplying a new state', async function () {
+        await this.controller.updateState({x: 'y'})
+
+        expect(await this.controller.readState()).to.deep.equal({x: 'y'})
+      })
+
+      it('should be able to replace the state with null by supplying null', async function () {
+        await this.controller.updateState(null)
+
+        expect(await this.controller.readState()).to.be.null()
+      })
+
+      it('should be able to replace the state by returning a new state', async function () {
+        await this.controller.updateState(nest)
+
+        expect(await this.controller.readState()).to.deep.equal({state: this.init})
+      })
+
+      it('should be able to replace the state with null by returning null', async function () {
+        await this.controller.updateState(destroy)
+
+        expect(await this.controller.readState()).to.be.null()
+      })
+
+      it('should not update the state if the update operation throws', async function () {
+        await expect(this.controller.updateState(explode)).to.be.rejectedWith(error)
+        expect(await this.controller.readState()).to.deep.equal(this.init)
+      })
+    })
+  })
+
+  context('when the state has been read', function () {
+    beforeEach(async function () {
+      this.state = await this.controller.readState()
+    })
+
+    it('should not be flagged as needing an update', function () {
+      expect(this.controller.isUpdated()).to.be.false()
+    })
+
+    describe('getState()', function () {
+      it('should be able to return the state', async function () {
+        expect(await this.controller.readState()).to.deep.equal(this.init)
+      })
+
+      it('should not cause additional calls of the read callback', async function () {
+        await this.controller.getState()
+
+        expect(this.read).to.have.been.calledOnce()
+      })
+    })
+
+    describe('readState()', function () {
+      it('should be able to read the state', async function () {
+        expect(await this.controller.readState()).to.deep.equal(this.init)
+      })
+
+      it('should return a copy of the state', async function () {
+        expect(await this.controller.readState()).to.not.equal(this.init)
+        expect(await this.controller.readState()).to.not.equal(this.state)
+      })
+
+      it('should not cause additional calls of the read callback', async function () {
+        await this.controller.readState()
+
+        expect(this.read).to.have.been.calledOnce()
+      })
+    })
+
+    describe('updateState()', function () {
+      it('should be able to update the state by mutation', async function () {
+        await this.controller.updateState(increment)
+
+        expect(await this.controller.readState()).to.deep.equal({number: 1})
+      })
+
+      it('should be able to replace the state by supplying a new state', async function () {
+        await this.controller.updateState({x: 'y'})
+
+        expect(await this.controller.readState()).to.deep.equal({x: 'y'})
+      })
+
+      it('should be able to replace the state with null by supplying null', async function () {
+        await this.controller.updateState(null)
+
+        expect(await this.controller.readState()).to.be.null()
+      })
+
+      it('should be able to replace the state by returning a new state', async function () {
+        await this.controller.updateState(nest)
+
+        expect(await this.controller.readState()).to.deep.equal({state: this.init})
+      })
+
+      it('should be able to replace the state with null by returning null', async function () {
+        await this.controller.updateState(destroy)
+
+        expect(await this.controller.readState()).to.be.null()
+      })
+
+      it('should not cause additional calls of the read callback', async function () {
+        await this.controller.updateState(null)
+
+        expect(this.read).to.have.been.calledOnce()
+      })
+
+      it('should not update the state if the update operation throws', async function () {
+        await expect(this.controller.updateState(explode)).to.be.rejectedWith(error)
+        expect(await this.controller.readState()).to.deep.equal(this.init)
+      })
+    })
+  })
+
+  context('when the state has been updated', function () {
+    beforeEach(async function () {
+      await this.controller.updateState(increment)
+      this.state = await this.controller.readState()
+    })
+
+    it('should be flagged as needing an update', function () {
+      expect(this.controller.isUpdated()).to.be.true()
+    })
+
+    describe('getState()', function () {
+      it('should be able to return the state', async function () {
+        expect(await this.controller.readState()).to.deep.equal(this.state)
+      })
+
+      it('should not cause additional calls of the read callback', async function () {
+        await this.controller.getState()
+
+        expect(this.read).to.have.been.calledOnce()
+      })
+    })
+
+    describe('readState()', function () {
+      it('should be able to read the state', async function () {
+        expect(await this.controller.readState()).to.deep.equal(this.state)
+      })
+
+      it('should return a copy of the state', async function () {
+        expect(await this.controller.readState()).to.not.equal(this.state)
+      })
+
+      it('should not cause additional calls of the read callback', async function () {
+        await this.controller.readState()
+
+        expect(this.read).to.have.been.calledOnce()
+      })
+    })
+
+    describe('updateState()', function () {
+      it('should be able to update the state by mutation', async function () {
+        await this.controller.updateState(increment)
+
+        expect(await this.controller.readState()).to.deep.equal({number: 2})
+      })
+
+      it('should be able to replace the state by supplying a new state', async function () {
+        await this.controller.updateState({x: 'y'})
+
+        expect(await this.controller.readState()).to.deep.equal({x: 'y'})
+      })
+
+      it('should be able to replace the state with null by supplying null', async function () {
+        await this.controller.updateState(null)
+
+        expect(await this.controller.readState()).to.be.null()
+      })
+
+      it('should be able to replace the state by returning a new state', async function () {
+        await this.controller.updateState(nest)
+
+        expect(await this.controller.readState()).to.deep.equal({state: this.state})
+      })
+
+      it('should be able to replace the state with null by returning null', async function () {
+        await this.controller.updateState(destroy)
+
+        expect(await this.controller.readState()).to.be.null()
+      })
+
+      it('should not cause additional calls of the read callback', async function () {
+        await this.controller.updateState(null)
+
+        expect(this.read).to.have.been.calledOnce()
+      })
+
+      it('should not update the state if the update operation throws', async function () {
+        await expect(this.controller.updateState(explode)).to.be.rejectedWith(error)
+        expect(await this.controller.readState()).to.deep.equal(this.state)
+      })
+    })
+  })
+
+  context('when the state has been updated by mutation', function () {
+    beforeEach(async function () {
+      await this.controller.updateState(state => {
+        ++state.number
+        this.draftState = state
+      })
+    })
+
+    it('should copy the supplied state to prevent mutations', async function () {
+      this.draftState.number = 'other'
+
+      expect(await this.controller.readState()).to.deep.equal({number: 1})
+    })
+  })
+
+  context('when the state has been updated by returning a new state', function () {
+    beforeEach(async function () {
+      this.state = {number: 111}
+      await this.controller.updateState(() => this.state)
+    })
+
+    it('should copy the supplied state to prevent mutations', async function () {
+      this.state.number = 222
+
+      expect(await this.controller.readState()).to.deep.equal({number: 111})
+    })
+  })
+
+  context('when the state has been updated by supplying a new state', function () {
+    beforeEach(async function () {
+      this.state = {number: 111}
+      await this.controller.updateState(this.state)
+    })
+
+    it('should copy the supplied state to prevent mutations', async function () {
+      this.state.number = 222
+
+      expect(await this.controller.readState()).to.deep.equal({number: 111})
+    })
+  })
+})

--- a/test/suite/maintain-command-handler.spec.js
+++ b/test/suite/maintain-command-handler.spec.js
@@ -36,7 +36,7 @@ describe('maintainCommandHandler()', pgSpec(function () {
           eventTypes: [eventTypeA, eventTypeB],
           routeCommand: () => instanceA,
           createInitialState: () => null,
-          handleCommand: ({command: {type, data}, recordEvents}) => {
+          handleCommand: async ({command: {type, data}, recordEvents}) => {
             switch (type) {
               case commandTypeA: return recordEvents({type: eventTypeA, data})
               case commandTypeB: return recordEvents({type: eventTypeB, data})


### PR DESCRIPTION
This PR will change the way state is presented to aggregates and processes, as well as the methods available to them for updating state. 

## Issues addressed

### Reading state

Currently, handlers **always** receive a `state` variable. This is not optimal for some handlers. Handlers can sometimes be completely stateless, or do not need to read the state in all cases.

### Updating state

There are currently various ways to update state:

- The supplied `state` can be mutated in aggregate `applyEvent` callbacks, or process `handleEvent` callbacks.
- The state can be replaced by calling `replaceState` in process `handleEvent` callbacks, but no equivalent exists for aggregates (which is inconsistent).

Having mutable state means that recluse cannot easily determine whether a handler actually made state changes. This means that currently, state must **always** be written after every invocation of a handler.

In addition, the current system offers little protection from leaky or incorrectly implemented handlers.

## Changes introduced

Handlers will now have a consistent API for reading and updating state:

- `readState()` - Lazily reads the current state
- `updateState(newState)` - Replace the current state without reading
- `updateState(produceFn)` - Update or replace the state using a callback that is passed the current state

### Usage

```js
const state = await readState()                   // read state
await updateState({foo: 'bar'})                   // replace state without reading
await updateState(state => { state.foo = 'baz' }) // modify state via mutation
await updateState(state => ({foo: 'qux'}))        // replace state via return value
```

Note that some aspects of aggregates will need to change to become `async` in order to take advantage of state. Specifically:

- Most `applyEvent` callbacks will become `async`
- Any usage of `recordEvents` is now `async` and must be used in conjunction with `await`

### Handler access

Aggregates will have access to `readState` **only** in `handleCommand` callbacks. Both `readState` and `updateState` will be available to `applyEvent` callbacks.

Both `readState` and `updateState` will be available to process `handleEvent` callbacks.

### Protection against unintended state mutation

Current state values are copied before they are passed to any `updateState` `produce` callback, and any new states supplied to `updateState` or returned from the `updateState` `produce` callback are immediately copied also. This provides fairly good insulation against state mutations made outside of `updateState` calls.

Because the most efficient method of copying state depends upon the serialization in use, the serialization API has grown a `copy` method. The serialization system might be renamed in future to acknowledge this additional responsibility.